### PR TITLE
Fix musl-gcc setup script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,7 +21,7 @@ git clone git://git.musl-libc.org/musl
 cd musl
 git checkout refs/tags/v0.9.15
 export CFLAGS="-fpie -fPIE"
-./configure
+./configure --prefix=/usr/local/musl --exec-prefix=/usr/local
 unset CFLAGS
 make -j2
 sudo make install


### PR DESCRIPTION
musl-gccのsetup scriptのconfigureを修正した（こうしないとパスの通っていない場所にmusl-gccが入ってしまう。）