### PR TITLE
Update .lvimrc for noexpandtab in Makefile

### DIFF
--- a/.lvimrc
+++ b/.lvimrc
@@ -1,3 +1,5 @@
-set expandtab
+if &ft != 'make'
+  set expandtab
+end
 set tabstop=2
 set shiftwidth=2


### PR DESCRIPTION
in Makefile, we should use hard tab so update .lvimrc to do so.