### PR TITLE
fix details (GenericFunction<> implementation)

### DIFF
--- a/source/kernel/function.h
+++ b/source/kernel/function.h
@@ -33,7 +33,15 @@ class GenericFunction {
  public:
   GenericFunction() {}
   virtual ~GenericFunction() {}
-  virtual R Execute(Args... args) = 0;
+  virtual R Execute(Args... args) {
+    // This Function must not be called.
+    // Because IsBaseOf<S,T>'s T must be abstract class.
+    // Following code call IsBaseOf.
+    // uptr<GenericFunction<void>>
+    kassert(false);
+    R r;
+    return r;
+  };
 };
 
 template <class... Args>

--- a/source/kernel/set.h
+++ b/source/kernel/set.h
@@ -36,6 +36,9 @@ class Set {
     _elem_list_head->next = _elem_list_head;
   }
   bool Push(sptr<S> t) {
+    if (t.IsNull()) {
+      return false;
+    }
     Locker locker(_lock);
     auto p = _elem_list_head;
     // Check same element

--- a/source/unit_test/set.cc
+++ b/source/unit_test/set.cc
@@ -42,6 +42,18 @@ private:
   Set<int> _set;
 } static OBJ(__LINE__);
 
+class SetTester_PushNull : public Tester {
+public:
+  virtual bool Test() override {
+    sptr<int> r1;
+    kassert(_set.Push(r1) == false);
+
+    return true;
+  }
+private:
+  Set<int> _set;
+} static OBJ(__LINE__);
+
 class SetTester_SinglePushPop : public Tester {
 public:
   virtual bool Test() override {


### PR DESCRIPTION
GenericFunction<>のExecuteの実装変更（インターフェイス変更なし

追記
2つ目のコミットで
_set.Push(null_sptr);したらPush()はfalseを返す
仕様を追加しました．
(本来はPR分けるべきかもしれないですが，変更のサイズが小さいのでいいかなぁと．．．）