### PR TITLE
Context Switch機能追加

### DIFF
--- a/source/arch/hw/arch_loader.h
+++ b/source/arch/hw/arch_loader.h
@@ -31,6 +31,7 @@
 #include <mem/kstack.h>
 #include <gdt.h>
 #include <tty.h>
+#include <idt.h>
 
 //TODO: using fs/gs registers
 
@@ -64,6 +65,39 @@ public:
   }
 
   ContextWrapper() {
+  }
+
+  ContextWrapper(Regs* rs) {
+    SaveContext(rs);
+  }
+
+  ContextWrapper(Context* c) {
+    _context = *c;
+  }
+
+  void SaveContext(Regs* rs) { 
+    _context.rip = rs->rip;
+    _context.rflags = rs->rflags;
+
+    _context.rdi = rs->rdi;
+    _context.rsi = rs->rsi;
+
+    _context.rsp = rs->rsp;
+    _context.rbp = rs->rbp;
+    
+    _context.rax = rs->rax;
+    _context.rbx = rs->rbx;
+    _context.rcx = rs->rcx;
+    _context.rdx = rs->rdx;
+
+    _context.r8 = rs->r8;
+    _context.r9 = rs->r9;
+    _context.r10 = rs->r10;
+    _context.r11 = rs->r11;
+    _context.r12 = rs->r12;
+    _context.r13 = rs->r13;
+    _context.r14 = rs->r14;
+
   }
 
   void SaveContext(size_t base,size_t stack) {

--- a/source/kernel/idt.cc
+++ b/source/kernel/idt.cc
@@ -67,6 +67,10 @@ extern "C" void handle_int(Regs *rs) {
   idt->_handling_cnt[cpuid]--;
   enable_interrupt(iflag);
 }
+extern "C" void handle_int_finish_for_contextswitch(Regs *rs) {
+  apic_ctrl->SendEoi(rs->n);
+  idt->_handling_cnt[cpu_ctrl->GetCpuId().GetRawId()]--;
+}
 }  // namespace C
 
 extern idt_callback vectors[256];

--- a/source/kernel/idt.h
+++ b/source/kernel/idt.h
@@ -41,7 +41,8 @@ typedef void (*ioint_callback)(void *arg);
 
 namespace C {
 extern "C" void handle_int(Regs *rs);
-}
+extern "C" void handle_int_finish_for_contextswitch(Regs *rs);
+}  // namespace C
 
 class Idt {
  public:
@@ -95,6 +96,7 @@ class Idt {
   } * *_callback;
   int *_handling_cnt;
   friend void C::handle_int(Regs *rs);
+  friend void C::handle_int_finish_for_contextswitch(Regs *rs);
   SpinLock _lock;
   bool _is_gen_initialized = false;
 };


### PR DESCRIPTION
10msごとにプロセスからスケジューラに処理が強制的に移動
HPETタイマの割り込みを使用

割り込みハンドラから現在実行中のプロセスのタスクを強制的にWaitさせる箇所で多少汚いコードになっています．修正の必要あり？